### PR TITLE
Add dbgeo requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "express": "^4.13.4",
     "mustache": "^2.2.1",
     "pg-promise": "^4.0.4",
-    "wkx": "^0.2.0"
+    "wkx": "^0.2.0",
+    "async": "~1.2.0",
+    "topojson": "~1.6.14",
+    "wellknown": "~0.3.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
After following the instructions in the README attempting to start the server returned this error

```
$ node server.js
module.js:338
    throw err;
          ^
Error: Cannot find module 'async'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at /Users/jwalgran/Projects/postgis-preview/dbgeo-modified.js:2:15
    at Object.<anonymous> (/Users/jwalgran/Projects/postgis-preview/dbgeo-modified.js:115:2)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
```

The modules required by `dbgeo-modified.js` were not included in `package.json`. After copying the values from the `dependencies` section of [dbgeo's package.json](https://github.com/jczaplew/dbgeo/blob/16074676303d3443a2bbf73e80048b8e2ffd9311/package.json) I was able to run the server without error and successfully visualize queries.