### PR TITLE
add localstorage history

### DIFF
--- a/public/js/components/Mirror.js
+++ b/public/js/components/Mirror.js
@@ -15,11 +15,17 @@ class Mirror extends React.Component {
     this.editor.setCursor(2, 0);
   }
 
-  getSQL() {
+  getValue() {
     return this.editor.getDoc().getValue();
   }
 
+  setValue(value) {
+    return this.editor.getDoc().setValue(value);
+  }
+
   render() {
+    const { query } = this.props;
+
     return (
       <textarea id="sqlPane" className="form-control" value="/* Type your SQL here */" readOnly></textarea>
     )


### PR DESCRIPTION
Restores localstorage query history.  

An array of 25 recent queries are stored in localstorage, with the query at index `0` being the most recently executed query.
Backward and Forward buttons are working, and become disabled at the appropriate times.

Closes #63;