### PR TITLE
✨  Sandwich layers under labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "test": "NODE_ENV=test node ./node_modules/mocha/bin/mocha ./test/**/*.js --exit",
     "start": "node server.js",
-    "devstart": "nodemon server.js"
+    "devstart": "NODE_ENV=development nodemon server.js"
   },
   "author": "",
   "license": "ISC"

--- a/public/js/components/App.js
+++ b/public/js/components/App.js
@@ -21,6 +21,7 @@ class App extends React.Component {
     };
 
     this.toggleMvt = this.toggleMvt.bind(this);
+    this.toggleAboveLabels = this.toggleAboveLabels.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleViewToggle = this.handleViewToggle.bind(this);
   }
@@ -49,18 +50,6 @@ class App extends React.Component {
     });
 
     this.mirror.setValue(historyQuery);
-  }
-
-  toggleMvt(e) {
-    if (e.target.checked) {
-      this.setState({ useTiles: true, geoJson: null });
-    } else {
-      this.setState({ useTiles: false, tiles: null, bounds: null });
-    }
-  }
-
-  handleViewToggle(view) {
-    this.setState({ view });
   }
 
   handleSubmit() {
@@ -136,11 +125,6 @@ class App extends React.Component {
     this.setState({ history });
   }
 
-<<<<<<< HEAD
-  handleSQLUpdate(SQL) {
-    this.setState({ SQL });
-  }
-
   toggleMvt(e) {
     if (e.target.checked) {
       this.setState({ useTiles: true, geoJson: null });
@@ -161,27 +145,6 @@ class App extends React.Component {
     this.setState({ view });
   }
 
-  getHistory(type) {
-    const { history } = this.state;
-    let { historyIndex } = this.state;
-
-    if (type === 'backward') {
-      historyIndex += 1;
-    } else {
-      historyIndex -= 1;
-    }
-
-    const historyQuery = history[historyIndex];
-
-    this.setState({
-      historyIndex,
-    });
-
-    this.mirror.setValue(historyQuery);
-  }
-
-=======
->>>>>>> 0ce5f8355311eee124bde195b8d9d4ee9b4fe1e6
   render() {
     const {
       bounds,
@@ -194,6 +157,7 @@ class App extends React.Component {
       rows,
       tiles,
       view,
+      geometriesAboveLabels,
     } = this.state;
 
     const noHistoryBack = historyIndex > history.length - 2;
@@ -305,50 +269,39 @@ class App extends React.Component {
                   Use MVT Tile Layers (For PostGIS 2.4+)
                 </label>
               </div>
-<<<<<<< HEAD
-
               <div className="form-check" style={{ marginTop: '5px' }}>
-                <input
-                  id="above-labels-toggle"
-                  className="form-check-input"
-                  type="checkbox"
-                  onChange={this.toggleAboveLabels.bind(this)}
-                />
                 <label
                   className="form-check-label"
                   htmlFor="above-labels-toggle"
                   style={{ marginLeft: '10px', userSelect: 'none', fontWeight: 200 }}
                 >
+                  <input
+                    id="above-labels-toggle"
+                    className="form-check-input"
+                    type="checkbox"
+                    onChange={this.toggleAboveLabels}
+                  />
                   Show results above map labels
                 </label>
               </div>
 
-=======
->>>>>>> 0ce5f8355311eee124bde195b8d9d4ee9b4fe1e6
               {notification}
             </div>
           </div>
-<<<<<<< HEAD
-          <Map
-            tiles={this.state.tiles}
-            geoJson={this.state.geoJson}
-            bounds={this.state.bounds}
-            visible={this.state.view === 'map'}
-            geometryType={this.state.geometryType}
-            geometriesAboveLabels={this.state.geometriesAboveLabels}
-=======
+
           <Map // eslint-disable-line
             tiles={tiles}
             geoJson={geoJson}
             bounds={bounds}
             visible={view === 'map'}
             geometryType={geometryType}
+            geometriesAboveLabels={geometriesAboveLabels}
+
           />
           <Table // eslint-disable-line
             rows={rows}
             featureCount={featureCount}
             visible={view === 'table'}
->>>>>>> 0ce5f8355311eee124bde195b8d9d4ee9b4fe1e6
           />
         </div>
       </div>

--- a/public/js/components/App.js
+++ b/public/js/components/App.js
@@ -17,6 +17,7 @@ class App extends React.Component {
       rows: null,
       view: 'map',
       geometryType: null,
+      geometriesAboveLabels: false,
     };
 
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -60,7 +61,7 @@ class App extends React.Component {
           } else {
             const geoJson = json;
             const featureCount = geoJson.features.length;
-            
+
             // Get the geometry type. Make sure we only look at features with a geometry
             const geometryType = geoJson.features.filter(feature => {
               if (feature.geometry && feature.geometry.type) {
@@ -114,6 +115,14 @@ class App extends React.Component {
       this.setState({ useTiles: true, geoJson: null });
     } else {
       this.setState({ useTiles: false, tiles: null, bounds: null });
+    }
+  }
+
+  toggleAboveLabels(e) {
+    if (e.target.checked) {
+      this.setState({ geometriesAboveLabels: true });
+    } else {
+      this.setState({ geometriesAboveLabels: false });
     }
   }
 
@@ -251,6 +260,22 @@ class App extends React.Component {
                 </label>
               </div>
 
+              <div className="form-check" style={{ marginTop: '5px' }}>
+                <input
+                  id="above-labels-toggle"
+                  className="form-check-input"
+                  type="checkbox"
+                  onChange={this.toggleAboveLabels.bind(this)}
+                />
+                <label
+                  className="form-check-label"
+                  htmlFor="above-labels-toggle"
+                  style={{ marginLeft: '10px', userSelect: 'none', fontWeight: 200 }}
+                >
+                  Show results above map labels
+                </label>
+              </div>
+
               {notification}
               <div id="download">
                 <h4>Download</h4>
@@ -269,6 +294,7 @@ class App extends React.Component {
             bounds={this.state.bounds}
             visible={this.state.view === 'map'}
             geometryType={this.state.geometryType}
+            geometriesAboveLabels={this.state.geometriesAboveLabels}
           />
           <Table rows={this.state.rows} featureCount={this.state.featureCount} visible={this.state.view === 'table'} />
         </div>

--- a/public/js/components/Map.js
+++ b/public/js/components/Map.js
@@ -111,14 +111,9 @@ class Map extends React.Component { // eslint-disable-line
     } = nextProps;
 
     const { geometriesAboveLabels } = this.props;
-    console.log('geometriesAboveLabels', geometriesAboveLabels, nextGeometriesAboveLabels)
-    console.log((geometriesAboveLabels !== nextGeometriesAboveLabels))
-    console.log((!!this.map.getLayer('postgis-preview')))
     if ((geometriesAboveLabels !== nextGeometriesAboveLabels) && (!!this.map.getLayer('postgis-preview'))) {
-      console.log('moving layer')
       this.map.moveLayer('postgis-preview', getBeforeLayer(nextGeometriesAboveLabels));
     } else {
-      console.log('adding layers')
       if (tiles) this.addTileLayer(tiles, geometryType, geometriesAboveLabels);
       if (geoJson) this.addJsonLayer(geoJson, geometryType, geometriesAboveLabels);
     }

--- a/public/js/components/Map.js
+++ b/public/js/components/Map.js
@@ -85,6 +85,7 @@ function getBeforeLayer(geometriesAboveLabels) {
 class Map extends React.Component { // eslint-disable-line
   constructor(props) {
     super(props);
+
     this.state = { zoomedToBounds: false };
   }
 
@@ -109,11 +110,15 @@ class Map extends React.Component { // eslint-disable-line
       geometriesAboveLabels: nextGeometriesAboveLabels,
     } = nextProps;
 
-    const { geometriesAboveLabels } = this.state;
-
+    const { geometriesAboveLabels } = this.props;
+    console.log('geometriesAboveLabels', geometriesAboveLabels, nextGeometriesAboveLabels)
+    console.log((geometriesAboveLabels !== nextGeometriesAboveLabels))
+    console.log((!!this.map.getLayer('postgis-preview')))
     if ((geometriesAboveLabels !== nextGeometriesAboveLabels) && (!!this.map.getLayer('postgis-preview'))) {
+      console.log('moving layer')
       this.map.moveLayer('postgis-preview', getBeforeLayer(nextGeometriesAboveLabels));
     } else {
+      console.log('adding layers')
       if (tiles) this.addTileLayer(tiles, geometryType, geometriesAboveLabels);
       if (geoJson) this.addJsonLayer(geoJson, geometryType, geometriesAboveLabels);
     }

--- a/public/js/components/Map.js
+++ b/public/js/components/Map.js
@@ -119,7 +119,7 @@ class Map extends React.Component {
   addJsonLayer(geoJson, geometryType) {
     removeLayers(this.map, this);
     const layerConfig = getLayerConfig(geoJson, geometryType);
-    this.map.addLayer(layerConfig);
+    this.map.addLayer(layerConfig, 'highway_name_other');
 
     const bounds = turf.bbox(geoJson);
 
@@ -132,7 +132,7 @@ class Map extends React.Component {
   addTileLayer(tiles, geometryType) {
     const layerConfig = getLayerConfig(tiles, geometryType);
     removeLayers(this.map, this);
-    this.map.addLayer(layerConfig);
+    this.map.addLayer(layerConfig, 'highway_name_other');
 
     if (this.props.bounds) {
       this.map.fitBounds(this.props.bounds, {

--- a/server.js
+++ b/server.js
@@ -44,4 +44,6 @@ app.listen(port);
 console.log(`Postgis Preview is listening on port ${port}...`); // eslint-disable-line
 
 // opens the url in the default browser
-opn(`http://localhost:${port}`);
+if (process.env.NODE_ENV !== 'development') {
+  opn(`http://localhost:${port}`);
+}


### PR DESCRIPTION
Sandwiches the new layers between the all of the basemap's point, polygon and polyline layers, and the basemaps' symbols, such as the labels.

https://www.useloom.com/share/aeef415e49c64766b5eeb83765db5d82

Warmup...

Not sure if we want this behaviour. Later on, this can be further enhanced through some boolean selector, that when toggled, removes all the custom PostGIS layers, and re-adds them in a manner which respects the preference. 

## TODO

- [x] Make this into a user-toggle
    - When toggled, the layer is removed and re-added in accordance with user preference