### PR TITLE
[Bugfix] Fix LineString Error

### DIFF
--- a/public/js/components/Map.js
+++ b/public/js/components/Map.js
@@ -42,7 +42,7 @@ function getLayerConfig(data, geometryType) {
       type: 'line',
       paint: {
         'line-color': 'rgba(52, 161, 255, 1)',
-        'line-width': '5',
+        'line-width': 5,
         'line-opacity': 0.7,
       },
     };


### PR DESCRIPTION
`line-width` expects a `number`, otherwise the following error occurs:

```
Error: layers.postgis-preview.paint.line-width: number expected, string found
    at Object.mr [as emitValidationErrors] (validate_style.js:27)
    at Fe (style.js:43)
    at i._validate (style.js:976)
    at i.addLayer (style.js:564)
    at o.addLayer (map.js:1227)
    at Map.addJsonLayer (<anonymous>:156:16)
    at Map.componentWillReceiveProps (<anonymous>:130:27)
    at react-dom.js:5065
    at measureLifeCyclePerf (react-dom.js:4529)
    at ReactCompositeComponentWrapper.updateComponent (react-dom.js:5064)
```